### PR TITLE
Make site mobile friendly, remove j20 ride link

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 <link rel="stylesheet" type="text/css" href="main.css">
 <meta charset='utf-8' />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link href='node-extras/fullcalendar/dist/fullcalendar.css' rel='stylesheet' />
 <link href='node-extras/fullcalendar/dist/fullcalendar.print.css' rel='stylesheet' media='print' />
 <script src='node-extras/moment/moment.js'></script>
@@ -42,6 +43,7 @@
                 center: 'title',
                 right: 'month,listWeek'
             },
+            height: 'auto',
             defaultView: 'listWeek',
             defaultDate: new Date().toJSON().slice(0,10),
             navLinks: true, // can click day/week names to navigate views
@@ -98,7 +100,11 @@
 </head>
 
 <body>
-    <h1><span class="r">Anarchist</span><span class="l">Events</span><span class="r">NYC</span></h1>
+    <h1>
+        <span class="r">Anarchist</span>
+        <span class="l">Events</span>
+        <span class="r">NYC</span>
+    </h1>
 
     <div class="about text">
         Public events of New York anarchist and anarchist-ish groups.
@@ -115,10 +121,6 @@
 
     <div class="to_add text">
         To add an event to this calendar, fill out <a href="https://docs.google.com/forms/d/13xhXjKkgpUy2NdsNVa3QAJxZesVuJrxic9yuzf882Pg">this form</a>. We prefer links to existing calendars or events.
-    </div>
-
-    <div class="about text">
-        For J20 ride requests and offers, fill out <a href="https://docs.google.com/forms/d/e/1FAIpQLSd16eK3gr8B4Z2mvTQJ1fUd9JHA9LzYbG3lqoFeYZ1AZaUlfQ/viewform">this form</a>.
     </div>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -70,6 +70,10 @@
                 })}
             },
 
+            viewRender: function() {
+                $('.fc-list-view .fc-scroller').css('height', 'auto');
+            },
+
             loading: function(bool) {
                 $('#loading').toggle(bool);
                 if (!bool && !initialized) {

--- a/main.css
+++ b/main.css
@@ -19,6 +19,7 @@ h1 {
     margin-bottom: 20px;
     text-align: center;
     border-bottom: 5px solid #444;
+    word-spacing: -0.3em;
 }
 .text {
     box-sizing: border-box;
@@ -63,6 +64,13 @@ body {
     max-width: 800px;
     margin: 0 auto;
 }
+
+@media all and (max-width:800px) {
+    #calendar {
+        margin: 0 -10px;
+    }
+}
+
 .the-base.fc-event, .the-base .fc-event-dot {
     background-color: blue;
 }


### PR DESCRIPTION
This makes the site look nicer on phones! Also removed the j20 ride link bc j20 is in the past.

Old:
<img width="250" alt="old" src="https://cloud.githubusercontent.com/assets/1229145/23319276/e37d8894-faa3-11e6-9433-559bcb5d1e28.png">

New:
<img height="400" alt="new" src="https://cloud.githubusercontent.com/assets/1229145/23319275/e3793064-faa3-11e6-8216-0db458e7fa6b.png">
